### PR TITLE
fixing the move command documentation to include the '=' sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `groll` command must be followed by one of the following options:
 - `prev`: Moves to the previous commit
 - `head`: Moves to the head of the commit history
 - `initial`: Moves to a commit with a message starting with "Initial state"
-- `move <commit>`: Moves to the given commit
+- `move=<commit>`: Moves to the given commit
 
 ## Contribution policy ##
 


### PR DESCRIPTION
To execute the "groll move" command, you have to include the '=' sign followed by the commit number. This wasn't shown correctly in the readme. This should fix that.
