### PR TITLE
Feature/help

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The `groll` command must be followed by one of the following arguments or option
 - `move=<commit>` – moves to the given commit
 - `push=<branch>` – pushes the current commit via HTTPS to the "origin-https" remote repository (needs to be defined!) under the given branch
 - `version` – shows the version of sbt-groll
+- `help` - shows this help info.
 
 ## Contribution policy ##
 

--- a/src/main/scala/de/heikoseeberger/sbtgroll/Groll.scala
+++ b/src/main/scala/de/heikoseeberger/sbtgroll/Groll.scala
@@ -122,6 +122,26 @@ private class Groll(state: State, grollArg: GrollArg) {
         case GrollArg.Version =>
           state.log.info(BuildInfo.version)
           state
+        case GrollArg.Help =>
+          state.log.info("Groll usage:")
+          state.log.info("Groll is helpfull when presenting using code.")
+          state.log.info("Use 'groll initial' to move the start for your presentation.")
+          state.log.info("Use 'groll next' to move forwards")
+          state.log.info("Use 'groll prev' to move backwards")
+          state.log.info("")
+          state.log.info("Available commands:")
+          state.log.info("show - shows the current commit id and message, if current commit is in history")
+          state.log.info("list - shows the full commit history")
+          state.log.info("next - moves to the next commit")
+          state.log.info("prev - moves to the previous commit")
+          state.log.info("head - moves to the head of the commit history")
+          state.log.info("""initial - moves to a commit with a message containing "groll:initial" or starting with "Initial state" or with tag "groll-initial" """)
+          state.log.info("move=<commit> - moves to the given commit")
+          state.log.info("push=<branch> - pushes the current commit via HTTPS to the \"origin-https\" remote repository (needs to be defined!) under the given branch")
+          state.log.info("version - shows the version of sbt-groll")
+          state.log.info("help - shows this help info")
+          state.log.info("See https://github.com/diversit/sbt-groll for more info about sbt-groll.")
+          state
       }
     }
   }

--- a/src/main/scala/de/heikoseeberger/sbtgroll/GrollArg.scala
+++ b/src/main/scala/de/heikoseeberger/sbtgroll/GrollArg.scala
@@ -37,4 +37,6 @@ private object GrollArg {
   case class Push(branch: String) extends GrollArg
 
   case object Version extends GrollArg
+
+  case object Help extends GrollArg
 }

--- a/src/main/scala/de/heikoseeberger/sbtgroll/GrollPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtgroll/GrollPlugin.scala
@@ -63,6 +63,6 @@ object GrollPlugin extends AutoPlugin {
       val name = classTag[A].runtimeClass.getSimpleName
       (Space ~> name.decapitalize ~> "=" ~> NotQuoted).map(ctor)
     }
-    arg(Show) | arg(List) | arg(Next) | arg(Prev) | arg(Head) | arg(Initial) | opt(Move) | opt(Push) | arg(Version)
+    arg(Show) | arg(List) | arg(Next) | arg(Prev) | arg(Head) | arg(Initial) | opt(Move) | opt(Push) | arg(Version) | arg(Help)
   }
 }


### PR DESCRIPTION
Added a 'help' command so you can get help from within sbt so you don't need to go to the sbt-groll page to know how to use it.

Note! The help info already contains info about the 'tag' support for the Initial command. See my other pull request.